### PR TITLE
fix imports to work with RN versions > 0.40

### DIFF
--- a/ios/RNPixelColor/RNPixelColor.h
+++ b/ios/RNPixelColor/RNPixelColor.h
@@ -1,4 +1,4 @@
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 
 @interface RNPixelColor : NSObject <RCTBridgeModule>
 

--- a/ios/RNPixelColor/RNPixelColor.m
+++ b/ios/RNPixelColor/RNPixelColor.m
@@ -1,5 +1,5 @@
 #include "RNPixelColor.h"
-#import "RCTImageLoader.h"
+#import <React/RCTImageLoader.h>
 #import "UIImage+ColorAtPixel.h"
 
 @implementation RNPixelColor


### PR DESCRIPTION
Required modifcations on iOS to compile due to RN 0.40+ breaking changes.